### PR TITLE
Add symlink forgotten in 40a8fc0

### DIFF
--- a/pcsc-relay/src/lock.c
+++ b/pcsc-relay/src/lock.c
@@ -1,0 +1,1 @@
+../../virtualsmartcard/src/vpcd/lock.c


### PR DESCRIPTION
Symlink to lock.c was still missing in 40a8fc0
