### PR TITLE
Add a basic .travis.yml file for automated testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,21 @@
+language: C
+before_install: sudo apt-get update
+install: sudo apt-get install help2man gengetopt libpcsclite-dev libusb-dev
+compiler:
+    - gcc
+env:
+    global:
+        -PKG_CONFIG_PATH=/tmp/install/lib/pkgconfig
+        -PREFIX=/tmp/install
+script:
+    #Build virtualsmartcard
+    - cd virtualsmartcard && autoreconf -vsi && ./configure && make && cd ..
+    # Build pcsc-relay, which requires libnfc
+    - cd /tmp && git clone https://code.google.com/p/libnfc && cd libnfc && autoreconf -i && ./configure --prefix=$PREFIX && make install && cd $TRAVIS_BUILD_DIR
+    - cd pcsc-relay && autoreconf -vsi && ./configure && make && cd ..
+    # Build libnpa, which requires OpenPACE and OpenSC
+    - cd /tmp && git clone https://github.com/frankmorgner/openpace && cd openpace && autoreconf -vsi && ./configure --enable-openssl-install --prefix=$PREFIX && make install && cd $TRAVIS_BUILD_DIR
+    - cd npa/src/opensc && cp configure.ac.in configure.ac && autoreconf -vsi && ./configure --prefix=$PREFIX --enable-sm && make install && cd ../../..
+#    - cd npa && autoreconf -vsi && ./configure OPENSC_LIBS="-L$PREFIX/lib -lopensc -lcrypto" && make
+#   # Build ccid 
+#    - cd ccid && autoreconf -vsi && ./configure OPENSC_LIBS="-L$PREFIX/lib -lopensc" && make


### PR DESCRIPTION
Perform some basic regression testing for the different modules of the virtualsmartcard repositories via Travis CI.

For now this only tries to build the different modules and doesn't perform any further tests. Also, the build of ccid and libnpa are commented out, since I couldn't get them to build. So there is lots of potential for improvement, but this can be used as a starting point.

If this pull request is accepted, testing has to be enabled for the virtualsmartcard repository in the Travis CI Account settings.
