### PR TITLE
Fix OpenSC compilation for TravisML tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ script:
     - cd pcsc-relay && autoreconf -vsi && ./configure && make && cd ..
     # Build libnpa, which requires OpenPACE and OpenSC
     - cd /tmp && git clone https://github.com/frankmorgner/openpace && cd openpace && autoreconf -vsi && ./configure --enable-openssl-install --prefix=$PREFIX && make install && cd $TRAVIS_BUILD_DIR
-    - cd npa/src/opensc && cp configure.ac.in configure.ac && autoreconf -vsi && ./configure --prefix=$PREFIX --enable-sm && make install && cd ../../..
+    - cd npa/src/opensc && autoreconf -vsi && ./configure --prefix=$PREFIX --enable-sm && make install && cd ../../..
 #    - cd npa && autoreconf -vsi && ./configure OPENSC_LIBS="-L$PREFIX/lib -lopensc -lcrypto" && make
     # Build ccid
     - cd ccid && autoreconf -vsi && ./configure OPENSSL_CFLAGS="-I$PREFIX/include" OPENSSL_LIBS="-L$PREFIX/lib -lcrypto" OPENSC_LIBS="-L$PREFIX/lib -lopensc" && make


### PR DESCRIPTION
Since the submodule was updated in 246db76 it is no longer necessary to rename configure.ac.in in order to be able to call autoreconf
