### PR TITLE
only usage help update: BirthName, ResidencePermit1 and ResidencePermit2

### DIFF
--- a/virtualsmartcard/src/vpicc/vicc.in
+++ b/virtualsmartcard/src/vpicc/vicc.in
@@ -95,7 +95,7 @@ The data groups in the data set file must have the following syntax: \
 --------------------------------------------------- \
 For Example: GivenNames=GERTRUD. \
 The following Dataset Elements may be used in the dataset file: \
-DocumentType, IssuingState, DateOfExpiry, GivenNames, FamilyNames, ReligiousArtisticName, AcademicTitle, DateOfBirth, PlaceOfBirth, Nationality, Sex, Country, City, ZIP, Street, CommunityID, dg12, dg13, dg14, dg15, dg16, dg19, dg20, dg21.\
+DocumentType, IssuingState, DateOfExpiry, GivenNames, FamilyNames, ReligiousArtisticName, AcademicTitle, DateOfBirth, PlaceOfBirth, Nationality, Sex, BirthName, Country, City, ZIP, Street, CommunityID, ResidencePermit1, ResidencePermit2, dg12, dg14, dg15, dg16, dg21.\
 ")
 
 


### PR DESCRIPTION
This is only the usage help update, the coding in CardGenerator.py will follow later
I have a problem in setup of ResidencePermit1 that it is recognized in eID service. This does not work:
....
dg19 = pack([(0x73, 0, [(0x0C, 0, ResidencePermit1)])], True)
dg20 = pack([(0x74, 0, [(0x0C, 0, ResidencePermit2)])], True)
....
