### PR TITLE
Add CardGenerator unit test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,22 +1,23 @@
 language: C
 before_install: sudo apt-get update
-install: sudo apt-get install help2man gengetopt libpcsclite-dev libusb-dev
+install: sudo apt-get install help2man gengetopt libpcsclite-dev libusb-dev swig python-dev
 compiler:
     - gcc
 env:
     global:
         -PKG_CONFIG_PATH=/tmp/install/lib/pkgconfig
         -PREFIX=/tmp/install
+        -PYTHONPATH=$PYTHONPATH:$PREFIX/lib/python2.7/site-packages/
 script:
+    # Build libnpa, which requires OpenPACE and OpenSC
+    - cd /tmp && git clone https://github.com/frankmorgner/openpace && cd openpace && autoreconf -vsi && ./configure --enable-openssl-install --enable-python --prefix=$PREFIX && make install && cd $TRAVIS_BUILD_DIR
+    - cd npa/src/opensc && autoreconf -vsi && ./configure --prefix=$PREFIX --enable-sm && make install && cd ../../..
+    - cd npa && autoreconf -vsi && ./configure OPENSC_LIBS="-L$PREFIX/lib -lopensc -lcrypto" && make && cd ..
     #Build virtualsmartcard
     - cd virtualsmartcard && autoreconf -vsi && ./configure && make
-    - cd src/vpicc/ && export PYTHONPATH=$PYTHONPATH:`pwd` && python -m unittest discover -s virtualsmartcard.tests -p *_test.py -v && cd $TRAVIS_BUILD_DIR
+    - cd src/vpicc/ && export PYTHONPATH=$PYTHONPATH:`pwd` && export LD_LIBRARY_PATH=$PREFIX/lib/ && python -m unittest discover -s virtualsmartcard.tests -p *_test.py -v && cd $TRAVIS_BUILD_DIR
     # Build pcsc-relay, which requires libnfc
     - cd /tmp && git clone https://code.google.com/p/libnfc && cd libnfc && autoreconf -i && ./configure --prefix=$PREFIX && make install && cd $TRAVIS_BUILD_DIR
     - cd pcsc-relay && autoreconf -vsi && ./configure && make && cd ..
-    # Build libnpa, which requires OpenPACE and OpenSC
-    - cd /tmp && git clone https://github.com/frankmorgner/openpace && cd openpace && autoreconf -vsi && ./configure --enable-openssl-install --prefix=$PREFIX && make install && cd $TRAVIS_BUILD_DIR
-    - cd npa/src/opensc && autoreconf -vsi && ./configure --prefix=$PREFIX --enable-sm && make install && cd ../../..
-    - cd npa && autoreconf -vsi && ./configure OPENSC_LIBS="-L$PREFIX/lib -lopensc -lcrypto" && make && cd ..
     # Build ccid
     - cd ccid && autoreconf -vsi && ./configure OPENSSL_CFLAGS="-I$PREFIX/include" OPENSSL_LIBS="-L$PREFIX/lib -lcrypto" OPENSC_LIBS="-L$PREFIX/lib -lopensc" && make

--- a/virtualsmartcard/src/vpicc/virtualsmartcard/tests/CardGenerator_test.py
+++ b/virtualsmartcard/src/vpicc/virtualsmartcard/tests/CardGenerator_test.py
@@ -1,0 +1,53 @@
+#
+# Copyright (C) 2014 Dominik Oepen
+#
+# This file is part of virtualsmartcard.
+#
+# virtualsmartcard is free software: you can redistribute it and/or modify it
+# under the terms of the GNU General Public License as published by the Free
+# Software Foundation, either version 3 of the License, or (at your option) any
+# later version.
+#
+# virtualsmartcard is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along with
+# virtualsmartcard.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+import unittest
+import tempfile
+import os
+from virtualsmartcard.CardGenerator import CardGenerator
+
+class TestNPACardGenerator(unittest.TestCase):
+
+    def setUp(self):
+        self.filename = tempfile.mktemp()
+        self.nPA_generator = CardGenerator('nPA')
+        self.nPA_generator.password = "TestPassword"
+
+    def tearDown(self):
+        os.unlink(self.filename)
+
+    def test_nPA_creation(self):
+        self.nPA_generator.generateCard()
+        self.nPA_generator.saveCard(self.filename)
+        mf, sam = self.nPA_generator.getCard()
+        self.assertIsNotNone(mf)
+        self.assertIsNotNone(sam)
+
+    def test_load_nPA_from_file_nPA_from_file(self):
+        self.nPA_generator.generateCard()
+        self.nPA_generator.saveCard(self.filename)
+        local_generator= CardGenerator('nPA')
+        local_generator.password = self.nPA_generator.password
+        local_generator.loadCard(self.filename)
+        mf, sam = local_generator.getCard()
+        self.assertIsNotNone(mf)
+        self.assertIsNotNone(sam)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Added a first unit test for the CardGenerator class. It currently only contains
test cases for generating a virtual nPA.

In order to use this test some changes to the TravisCI configuration are
required. Especially the OpenPACE python bindings need to be build before
vsmartcard is being tested since the vsmartcard nPA functions use these
bindings.
