### PR TITLE
Remove AM_COND_IF from configure.ac as older automake versions do not…

### DIFF
--- a/virtualsmartcard/configure.ac
+++ b/virtualsmartcard/configure.ac
@@ -166,8 +166,9 @@ LIBS="$LDFLAGS $QRENCODE_LIBS"
 AC_CHECK_HEADERS(qrencode.h, [], [ HAVE_QRENCODE=no ])
 AC_MSG_CHECKING([for QRcode_encodeString])
 AC_TRY_LINK_FUNC(QRcode_encodeString, [ AC_MSG_RESULT([yes]) ], [ HAVE_QRENCODE=no ])
-AM_CONDITIONAL(HAVE_QRENCODE, test "${HAVE_QRENCODE}" = "yes")
-AM_COND_IF(HAVE_QRENCODE, [AC_DEFINE(HAVE_QRENCODE, 1, [enable QR support])])
+if test "${HAVE_QRENCODE}" = "yes"; then
+	AC_DEFINE(HAVE_QRENCODE, 1, [enable QR support])
+fi
 CPPFLAGS="$saved_CPPFLAGS"
 LIBS="$saved_LIBS"
 


### PR DESCRIPTION
… support this macro

On SLES SP3 the automake tool has Version 1.10.1 and it does not know the new introducted AM_COND_IF macro.
I found the related work around on Mailing list of automake from year 2009
http://lists.gnu.org/archive/html/automake/2009-01/msg00011.html
since AM_COND_IF is not available in old Versions, the way is to use simple shell if statements as done in your configure.ac several times.