### PR TITLE
import sys was missing

### DIFF
--- a/virtualsmartcard/src/vpicc/virtualsmartcard/cards/nPA.py
+++ b/virtualsmartcard/src/vpicc/virtualsmartcard/cards/nPA.py
@@ -27,7 +27,7 @@ from virtualsmartcard.utils import inttostring, R_APDU
 import virtualsmartcard.CryptoUtils as vsCrypto
 from chat import CHAT, CVC, PACE_SEC, EAC_CTX
 import eac
-import logging, binascii
+import logging, binascii, sys
 
 
 class NPAOS(Iso7816OS):


### PR DESCRIPTION
during execution in nPA mode, the process stops due to "NameError: global Name 'sys' is not defined"
It's simply the missing "import sys"