### PR TITLE
check for help2man fixed

### DIFF
--- a/virtualsmartcard/configure.ac
+++ b/virtualsmartcard/configure.ac
@@ -34,7 +34,7 @@ AX_PTHREAD
 AC_ARG_VAR([HELP2MAN],
            [absolute path to help2man used for man page generation of vicc])
 AC_PATH_PROG(HELP2MAN, help2man, not found)
-if test ! -r src/vpicc/vicc.1 -a "${HELP2MAN}" = "not found"
+if test ! -x "${HELP2MAN}"
 then
     AC_MSG_ERROR([Need help2man to generate man page for vicc])
 fi


### PR DESCRIPTION
As seen in issue 60 again....
The check "${HELP2MAN}" = "not found" did not proper detect missing help2man
changed it to if test ! -x "${HELP2MAN}"