### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/ACardEmulator/README.md
+++ b/ACardEmulator/README.md
@@ -1,4 +1,4 @@
-#Android Smart Card Emulator
+# Android Smart Card Emulator
 
 The Android Smart Card Emulator allows the emulation of a contact-less smart card.
 The emulator uses Android's HCE to fetch APDUs from a contact-less reader.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-#Virtual Smart Card Architecture
+# Virtual Smart Card Architecture
 
 Virtual Smart Card Architecture is an umbrella project for various
 projects concerned with the emulation of different types of smart card readers

--- a/TCardEmulator/README.md
+++ b/TCardEmulator/README.md
@@ -1,4 +1,4 @@
-#Tizen Smart Card Emulator
+# Tizen Smart Card Emulator
 
 The Tizen Smart Card Emulator allows the emulation of a contact-less smart
 card.  The emulator uses Tizen's HCE to fetch APDUs from a contact-less reader.

--- a/ccid/README.md
+++ b/ccid/README.md
@@ -1,4 +1,4 @@
-#USB CCID Emulator
+# USB CCID Emulator
 
 The USB CCID Emulator forwards a locally present PC/SC smart card reader as a
 standard USB CCID reader. USB CCID Emulator can be used as trusted intermediary

--- a/npa/README.md
+++ b/npa/README.md
@@ -1,4 +1,4 @@
-#nPA Smart Card Library
+# nPA Smart Card Library
 
 Access the German electronic identity card (neuer Personalausweis/nPA).
 

--- a/pcsc-relay/README.md
+++ b/pcsc-relay/README.md
@@ -1,4 +1,4 @@
-#PC/SC Relay
+# PC/SC Relay
 
 Welcome to PC/SC Relay. The purpose of PC/SC Relay is to relay a smart
 card using an contact-less interface. Currently the following contact-less

--- a/remote-reader/README.md
+++ b/remote-reader/README.md
@@ -1,4 +1,4 @@
-#Remote Smart Card Reader
+# Remote Smart Card Reader
 
 Allow a host computer to use the smartphone's NFC hardware as contact-less
 smartcard reader. On the host computer a special smart card driver,

--- a/virtualsmartcard/README.md
+++ b/virtualsmartcard/README.md
@@ -1,4 +1,4 @@
-#Virtual Smart Card
+# Virtual Smart Card
 
 Virtual Smart Card emulates a smart card and makes it accessible through PC/SC.
 Currently the Virtual Smart Card supports the following types of smart cards:


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
