### PR TITLE
Make the Relay card still parse and log the APDU

### DIFF
--- a/virtualsmartcard/src/vpicc/virtualsmartcard/cards/Relay.py
+++ b/virtualsmartcard/src/vpicc/virtualsmartcard/cards/Relay.py
@@ -22,7 +22,7 @@ import logging
 import smartcard
 import sys
 from virtualsmartcard.VirtualSmartcard import SmartcardOS
-
+from virtualsmartcard.utils import C_APDU
 
 class RelayOS(SmartcardOS):
     """
@@ -113,6 +113,13 @@ class RelayOS(SmartcardOS):
         self.powerUp()
 
     def execute(self, msg):
+        try:
+            c = C_APDU(msg)
+            logging.info("Parsed APDU:\n%s", str(c))
+        except ValueError as e:
+            # ignore the parse failure, just don't log the parsed APDU
+            logging.warning("Could not parse APDU:%s", str(e))
+
         # sendCommandAPDU() expects a list of APDU bytes
         apdu = map(ord, msg)
 


### PR DESCRIPTION
The basic VirtualSmartcard implementation parses and logs the APDU sent
to the card in the execute instance method, and logs the received APDU
after calling that method.

The Relay implementation, however, overrides the execute method, but
does not log it. The result, when running at the info log level, is that
you see the reply from the card, but not the request from the
application. This is confusing.

Additionally, if the relay implementation shows the request APDU, then
it can be used as a method to analyze what an application is trying to
do.

To remedy all that, parse the APDU and log that parsed value, but don't
do anything further with it.

Signed-off-by: Wouter Verhelst <w@uter.be>