### PR TITLE
Fix SFID parameter in FCP template

### DIFF
--- a/virtualsmartcard/src/vpicc/virtualsmartcard/SmartcardFilesystem.py
+++ b/virtualsmartcard/src/vpicc/virtualsmartcard/SmartcardFilesystem.py
@@ -594,7 +594,7 @@ class MF(DF):
         # TODO filesize and data objects
         if isinstance(file, EF):
             if hasattr(file, 'shortfid'):
-                fdm.append("%c\x01%c" % (TAG["SHORTFID"], file.shortfid))
+                fdm.append("%c\x01%c" % (TAG["SHORTFID"], file.shortfid << 3))
             else:
                 fdm.append("%c\x00" % TAG["SHORTFID"])
 


### PR DESCRIPTION
In FCP SFID tag bits 8 to 4 encode the short EF identifier.