### PR TITLE
Fix selection by DF name

### DIFF
--- a/virtualsmartcard/src/vpicc/virtualsmartcard/SmartcardFilesystem.py
+++ b/virtualsmartcard/src/vpicc/virtualsmartcard/SmartcardFilesystem.py
@@ -197,10 +197,6 @@ def prettyprint_anything(indent, thing):
     s = "%s{%s at 0x%x}:" % (indent, thing.__class__.__name__, id(thing))
     indent = indent + "  "
     for (attribute, newvalue) in thing.__dict__.items():
-        # FIXME: ugly hack to prevent infinite recursion when prettyprinting MF:
-        if attribute == 'named_dfs':
-            continue
-
         if isinstance(newvalue, int):
             s = s + "\n" + indent + attribute + (16-len(attribute)) * " " +\
                 "0x%x" % (newvalue)
@@ -539,6 +535,7 @@ class MF(DF):
     secondSFT = make_property("secondSFT", "string of length 1. The second"
                                            "software function table from the"
                                            "historical bytes.")
+    named_dfs = make_property("named_dfs", "list of DFs with dfname specified")
 
     def __init__(self, filedescriptor=FDB["NOTSHAREABLEFILE"] | FDB["DF"],
                  lifecycle=LCB["ACTIVATED"],

--- a/virtualsmartcard/src/vpicc/virtualsmartcard/SmartcardFilesystem.py
+++ b/virtualsmartcard/src/vpicc/virtualsmartcard/SmartcardFilesystem.py
@@ -197,6 +197,10 @@ def prettyprint_anything(indent, thing):
     s = "%s{%s at 0x%x}:" % (indent, thing.__class__.__name__, id(thing))
     indent = indent + "  "
     for (attribute, newvalue) in thing.__dict__.items():
+        # FIXME: ugly hack to prevent infinite recursion when prettyprinting MF:
+        if attribute == 'named_dfs':
+            continue
+
         if isinstance(newvalue, int):
             s = s + "\n" + indent + attribute + (16-len(attribute)) * " " +\
                 "0x%x" % (newvalue)

--- a/virtualsmartcard/src/vpicc/virtualsmartcard/SmartcardFilesystem.py
+++ b/virtualsmartcard/src/vpicc/virtualsmartcard/SmartcardFilesystem.py
@@ -207,7 +207,10 @@ def prettyprint_anything(indent, thing):
         elif isinstance(newvalue, list):
             s = s + "\n" + indent + attribute + (16 - len(attribute)) * " "
             for item in newvalue:
-                s = s + "\n" + prettyprint_anything(indent + "  ", item)
+                if attribute == '_named_dfs':
+                    s = s + "\n" + "%s%s" % (indent + "  ", hexdump(item.dfname, short=True))
+                else:
+                    s = s + "\n" + prettyprint_anything(indent + "  ", item)
     return s
 
 


### PR DESCRIPTION
DF names shall be globally uniqe within a given card. Selecting by DF
name should be made on card level instead of current DF level.

A new list has been inroduced as a static attribute of MF in order to
track each named DF.