### PR TITLE
Configurable read timeout (remote-reader)

### DIFF
--- a/remote-reader/app/src/main/java/com/vsmartcard/remotesmartcardreader/app/MainActivity.java
+++ b/remote-reader/app/src/main/java/com/vsmartcard/remotesmartcardreader/app/MainActivity.java
@@ -158,7 +158,7 @@ public class MainActivity extends AppCompatActivity implements NfcAdapter.Reader
         setRequestedOrientation(ActivityInfo.SCREEN_ORIENTATION_NOSENSOR);
 
         SharedPreferences SP = PreferenceManager.getDefaultSharedPreferences(this);
-        int timeout = Integer.parseInt(SP.getString("delay", Integer.toString(NFCReader.TIMEOUT)));
+        int timeout = Integer.parseInt(SP.getString("delay", "500"));
         Bundle bundle = new Bundle();
         bundle.putInt(NfcAdapter.EXTRA_READER_PRESENCE_CHECK_DELAY, timeout * 10);
         adapter.enableReaderMode(this, this,

--- a/remote-reader/app/src/main/java/com/vsmartcard/remotesmartcardreader/app/SettingsActivity.java
+++ b/remote-reader/app/src/main/java/com/vsmartcard/remotesmartcardreader/app/SettingsActivity.java
@@ -168,6 +168,7 @@ public class SettingsActivity extends AppCompatPreferenceActivity {
             bindPreferenceSummaryToValue(findPreference("hostname"));
             bindPreferenceSummaryToValue(findPreference("port"));
             bindPreferenceSummaryToValue(findPreference("delay"));
+            bindPreferenceSummaryToValue(findPreference("timeout"));
 
             Preference nfcSettings = findPreference("nfcSettings");
             nfcSettings.setOnPreferenceClickListener(new Preference.OnPreferenceClickListener() {

--- a/remote-reader/app/src/main/java/com/vsmartcard/remotesmartcardreader/app/screaders/NFCReader.java
+++ b/remote-reader/app/src/main/java/com/vsmartcard/remotesmartcardreader/app/screaders/NFCReader.java
@@ -21,12 +21,14 @@ package com.vsmartcard.remotesmartcardreader.app.screaders;
 
 import android.app.Activity;
 import android.content.Intent;
+import android.content.SharedPreferences;
 import android.nfc.NfcAdapter;
 import android.nfc.Tag;
 import android.nfc.tech.IsoDep;
 import android.os.Build;
 import android.os.Handler;
 import android.os.Looper;
+import android.preference.PreferenceManager;
 import android.util.Log;
 import android.view.WindowManager;
 
@@ -42,7 +44,10 @@ public class NFCReader implements SCReader {
     private NFCReader(IsoDep sc, Activity activity) throws IOException {
         this.card = sc;
         sc.connect();
-        card.setTimeout(TIMEOUT);
+        SharedPreferences SP = PreferenceManager.getDefaultSharedPreferences(activity);
+        int timeout = Integer.parseInt(SP.getString("timeout", "500"));
+        card.setTimeout(timeout);
+        com.example.android.common.logger.Log.i(getClass().getName(), "Timeout set to " + Integer.toString(timeout));
         this.activity = activity;
         avoidScreenTimeout();
     }
@@ -81,7 +86,6 @@ public class NFCReader implements SCReader {
         resetScreenTimeout();
     }
 
-    public static final int TIMEOUT = 500;
     @Override
     public void powerOn() {
         /* should already be connected... */

--- a/remote-reader/app/src/main/res/values/strings.xml
+++ b/remote-reader/app/src/main/res/values/strings.xml
@@ -21,6 +21,24 @@
         <item>1000</item>
         <item>2000</item>
     </string-array>
+    <string-array name="strTimeouts">
+        <item>125 milliseconds</item>
+        <item>250 milliseconds</item>
+        <item>500 milliseconds</item>
+        <item>1 second</item>
+        <item>2 seconds</item>
+        <item>3 seconds</item>
+        <item>4 seconds</item>
+    </string-array>
+    <string-array name="intTimeouts">
+        <item>125</item>
+        <item>250</item>
+        <item>500</item>
+        <item>1000</item>
+        <item>2000</item>
+        <item>3000</item>
+        <item>4000</item>
+    </string-array>
 
     <string name="action_settings">Settings</string>
     <string name="action_copy">Copy Log</string>

--- a/remote-reader/app/src/main/res/xml/settings.xml
+++ b/remote-reader/app/src/main/res/xml/settings.xml
@@ -50,6 +50,13 @@
             android:entries="@array/strDelays"
             android:entryValues="@array/intDelays" />
 
+        <ListPreference
+            android:key="timeout"
+            android:defaultValue="500"
+            android:title="Delay for Card Response"
+            android:entries="@array/strTimeouts"
+            android:entryValues="@array/intTimeouts" />
+
     </PreferenceCategory>
 
 </PreferenceScreen>


### PR DESCRIPTION
A quick modification to allow configuring an NFC response timeout for the remote-reader app.
I removed the `public static int TIMEOUT` field from `NFCReader`. I substituted the only other usage (in `MainActivity`, used for the default value of `EXTRA_READER_PRESENCE_CHECK_DELAY`) with its former value.

An increased timeout enables use of this app for Hungarian E-IDs (as discussed in issue #123 )