### PR TITLE
(partially) fix macOS 10.14/Xcode 11.0 compile and install issues

### DIFF
--- a/pcsc-relay/configure.ac
+++ b/pcsc-relay/configure.ac
@@ -74,7 +74,7 @@ PKG_CHECK_EXISTS([libpcsclite],
 						SDK_PATH="${SDK_PATH:-$SDKS_PATH/$(ls -1 ${SDKS_PATH} | sort -n -t. -k2 -r | head -1)}"
 						# and set the PC/SC include path
 						PCSC_CFLAGS="-I$SDK_PATH/System/Library/Frameworks/PCSC.framework/Versions/Current/Headers -DRESPONSECODE_DEFINED_IN_WINTYPES_H -I`pwd`/${top_srcdir}/MacOSX"
-						PCSC_LIBS="--framework PCSC"
+						PCSC_LIBS="-framework PCSC"
 				 esac
 				 ])
 

--- a/virtualsmartcard/MacOSX/Makefile.am
+++ b/virtualsmartcard/MacOSX/Makefile.am
@@ -14,12 +14,17 @@ osx: $(OPENPACE_MAKEFILE)
 	rm -rf $(OSX_TARGETDIR) dmg $(top_builddir)/$(PACKAGE_TARNAME)-$(PACKAGE_VERSION)_osx.dmg
 	@echo Configuring virtualsmartcard for IFD bundle
 	cd $(top_builddir) && ./configure --prefix=/Library/VirtualSmartCard \
-		CFLAGS="-arch i386 -arch x86_64" --enable-infoplist
+		CFLAGS="-arch i386 -arch x86_64" \
+		--enable-serialdropdir=/usr/libexec/SmartCardServices/drivers/ifd-vpcd.bundle/Contents/MacOS \
+		--enable-serialconfdir=/usr/libexec/SmartCardServices/drivers/ifd-vpcd.bundle/Contents
 	@echo Compiling virtualsmartcard
 	make -C $(top_builddir) clean install DESTDIR=$(OSX_TARGETDIR)
 	@echo Configuring virtualsmartcard for builtin libpcsclite
 	cd $(top_builddir) && ./configure --prefix=/Library/VirtualSmartCard \
-		CFLAGS="-arch i386 -arch x86_64" --enable-libpcsclite
+		CFLAGS="-arch i386 -arch x86_64" \
+		--enable-serialdropdir=/usr/libexec/SmartCardServices/drivers/ifd-vpcd.bundle/Contents/MacOS \
+		--enable-serialconfdir=/usr/libexec/SmartCardServices/drivers/ifd-vpcd.bundle/Contents \
+		--enable-libpcsclite
 	@echo Compiling virtualsmartcard
 	make -C $(top_builddir) clean install DESTDIR=$(OSX_TARGETDIR)
 	pkgbuild --root $(OSX_TARGETDIR) --scripts MacOSX_install --identifier com.vsmartcard.virtualsmartcard.mac --version $(PACKAGE_VERSION) --install-location / VirtualSmartCard-$(PACKAGE_VERSION)_install.pkg

--- a/virtualsmartcard/MacOSX/Makefile.am
+++ b/virtualsmartcard/MacOSX/Makefile.am
@@ -14,14 +14,14 @@ osx: $(OPENPACE_MAKEFILE)
 	rm -rf $(OSX_TARGETDIR) dmg $(top_builddir)/$(PACKAGE_TARNAME)-$(PACKAGE_VERSION)_osx.dmg
 	@echo Configuring virtualsmartcard for IFD bundle
 	cd $(top_builddir) && ./configure --prefix=/Library/VirtualSmartCard \
-		CFLAGS="-arch i386 -arch x86_64" \
+		CFLAGS="-arch x86_64" \
 		--enable-serialdropdir=/usr/libexec/SmartCardServices/drivers/ifd-vpcd.bundle/Contents/MacOS \
 		--enable-serialconfdir=/usr/libexec/SmartCardServices/drivers/ifd-vpcd.bundle/Contents
 	@echo Compiling virtualsmartcard
 	make -C $(top_builddir) clean install DESTDIR=$(OSX_TARGETDIR)
 	@echo Configuring virtualsmartcard for builtin libpcsclite
 	cd $(top_builddir) && ./configure --prefix=/Library/VirtualSmartCard \
-		CFLAGS="-arch i386 -arch x86_64" \
+		CFLAGS="-arch x86_64" \
 		--enable-serialdropdir=/usr/libexec/SmartCardServices/drivers/ifd-vpcd.bundle/Contents/MacOS \
 		--enable-serialconfdir=/usr/libexec/SmartCardServices/drivers/ifd-vpcd.bundle/Contents \
 		--enable-libpcsclite

--- a/virtualsmartcard/configure.ac
+++ b/virtualsmartcard/configure.ac
@@ -100,7 +100,17 @@ if test "${libpcsclite}" = no ; then
 			serialdropdir="`$PKG_CONFIG libpcsclite --variable=usbdropdir`/serial"
 			if test "${serialdropdir}" = "/serial" ; then
 				case "$host" in
-					*-*-darwin*) serialdropdir=/usr/libexec/SmartCardServices/drivers/ifd-vpcd.bundle/Contents/MacOS; infoplist=yes ;;
+					*-*-darwin*)
+						MAC_VERSION=$(sw_vers -productVersion | awk -F '.' '{print $1 * 1000 + $2}')
+						if test "$MAC_VERSION" -ge "10011"; then
+							# System Integrity Protection means we can't write
+							# to /usr/libexec; even as root!
+							serialdropdir=/usr/local/libexec/SmartCardServices/drivers/ifd-vpcd.bundle/Contents/MacOS
+						else
+							serialdropdir=/usr/libexec/SmartCardServices/drivers/ifd-vpcd.bundle/Contents/MacOS
+						fi
+						infoplist=yes
+						;;
 					*) AC_MSG_ERROR([use --enable-serialdropdir=DIR])
 				esac
 			fi
@@ -108,7 +118,17 @@ if test "${libpcsclite}" = no ; then
 			serialdropdir="${prefix}`$PKG_CONFIG libpcsclite --variable=usbdropdir`/serial"
 			if test "${serialdropdir}" = "${prefix}/serial" ; then
 				case "$host" in
-					*-*-darwin*) serialdropdir=${prefix}/usr/libexec/SmartCardServices/drivers/ifd-vpcd.bundle/Contents/MacOS; infoplist=yes ;;
+					*-*-darwin*)
+						MAC_VERSION=$(sw_vers -productVersion | awk -F '.' '{print $1 * 1000 + $2}')
+						if test "$MAC_VERSION" -ge "10011"; then
+							# System Integrity Protection means we can't write
+							# to /usr/libexec; even as root!
+							serialdropdir=${prefix}/usr/local/libexec/SmartCardServices/drivers/ifd-vpcd.bundle/Contents/MacOS
+						else
+							serialdropdir=${prefix}/usr/libexec/SmartCardServices/drivers/ifd-vpcd.bundle/Contents/MacOS
+						fi
+						infoplist=yes
+						;;
 					*) AC_MSG_ERROR([use --enable-serialdropdir=DIR])
 				esac
 			fi
@@ -126,7 +146,17 @@ if test "${libpcsclite}" = no ; then
 			serialconfdir="`$PKG_CONFIG libpcsclite --variable=serialconfdir`"
 			if test "${serialconfdir}" = "" ; then
 				case "$host" in
-					*-*-darwin*) serialconfdir=/usr/libexec/SmartCardServices/drivers/ifd-vpcd.bundle/Contents; infoplist=yes ;;
+					*-*-darwin*)
+					MAC_VERSION=$(sw_vers -productVersion | awk -F '.' '{print $1 * 1000 + $2}')
+					if test "$MAC_VERSION" -ge "10011"; then
+						# System Integrity Protection means we can't write
+						# to /usr/libexec; even as root!
+						serialconfdir=/usr/local/libexec/SmartCardServices/drivers/ifd-vpcd.bundle/Contents
+					else
+						serialconfdir=/usr/libexec/SmartCardServices/drivers/ifd-vpcd.bundle/Contents
+					fi
+					infoplist=yes
+					;;
 					*) serialconfdir="/etc/reader.conf.d"
 				esac
 			fi
@@ -134,7 +164,17 @@ if test "${libpcsclite}" = no ; then
 			serialconfdir="${prefix}`$PKG_CONFIG libpcsclite --variable=serialconfdir`"
 			if test "${serialconfdir}" = "${prefix}" ; then
 				case "$host" in
-					*-*-darwin*) serialconfdir=${prefix}/usr/libexec/SmartCardServices/drivers/ifd-vpcd.bundle/Contents; infoplist=yes ;;
+					*-*-darwin*)
+					MAC_VERSION=$(sw_vers -productVersion | awk -F '.' '{print $1 * 1000 + $2}')
+					if test "$MAC_VERSION" -ge "10011"; then
+						# System Integrity Protection means we can't write
+						# to /usr/libexec; even as root!
+						serialconfdir=${prefix}/usr/local/libexec/SmartCardServices/drivers/ifd-vpcd.bundle/Contents
+					else
+						serialconfdir=${prefix}/usr/libexec/SmartCardServices/drivers/ifd-vpcd.bundle/Contents
+					fi
+					infoplist=yes
+					;;
 					*) serialconfdir="${prefix}/etc/reader.conf.d"
 				esac
 			fi


### PR DESCRIPTION
Fixes compile errors in `pcsc-relay` on macOS 10.14 with Xcode 11.0 toolchain:

```
checking for SCardEstablishContext... configure: error: libpcsclite not found, use ./configure PCSC_LIBS=...
make[1]: *** [config.status] Error 1
make: *** [../aclocal.m4] Error 2
```

This is caused by using `--framework PCSC` instead of `-framework PCSC`.

Also fixes an issue with `make install` on `virtualsmartcard` on macOS 10.11+ (System Integrity Protection).  This fix was already in the macOS package installer, but wasn't in `configure.ac` so `make install` would fail.

I also _reversed_ those changes for `MacOSX/Makefile.am`, because then the paths are consistent regardless of whether it was built on macOS 10.11+ or not... but **this is still broken with macOS 10.14**.

This also fixes an error with `--enable-infoplist` no longer being an option.

I've also removed building for `i386`, because this is not supported by Xcode 11, and builds fail without it.  Such is the march of progress...