### PR TITLE
basic Man-in-the-Middle extension to the Relay-Card

### DIFF
--- a/virtualsmartcard/src/vpicc/Makefile.am
+++ b/virtualsmartcard/src/vpicc/Makefile.am
@@ -24,6 +24,7 @@ vpicccards_PYTHON = virtualsmartcard/cards/__init__.py \
            virtualsmartcard/cards/ePass.py \
            virtualsmartcard/cards/nPA.py \
            virtualsmartcard/cards/Relay.py \
+           virtualsmartcard/cards/RelayMiddleman.py \
            virtualsmartcard/cards/cryptoflex.py
 
 do_subst = $(SED) \

--- a/virtualsmartcard/src/vpicc/vicc.in
+++ b/virtualsmartcard/src/vpicc/vicc.in
@@ -66,6 +66,10 @@ relay.add_argument("--reader",
         type=int,
         default=0,
         help="number of the reader containing the card to be relayed (default: %(default)s)")
+relay.add_argument("--mitm",
+        action="store",
+        type=str,
+        help="relative path to a file containing a Man-in-the-Middle class that is supposed to be used with the relay")
 
 npa = parser.add_argument_group('Emulation of German identity card (`--type=nPA`)')
 npa.add_argument("--ef-cardaccess",
@@ -153,7 +157,7 @@ else:
     hostname = args.hostname
 
 vicc = VirtualICC(args.datasetfile, args.type, hostname, args.port,
-        readernum=args.reader, ef_cardaccess=ef_cardaccess_data,
+        readernum=args.reader, mitmPath=args.mitm, ef_cardaccess=ef_cardaccess_data,
         ef_cardsecurity=ef_cardsecurity_data, ca_key=ca_key_data, cvca=cvca,
         disable_checks=args.disable_ta_checks, esign_ca_cert=esign_ca_cert,
         esign_cert=esign_cert, logginglevel=logginglevel)

--- a/virtualsmartcard/src/vpicc/virtualsmartcard/cards/RelayMiddleman.py
+++ b/virtualsmartcard/src/vpicc/virtualsmartcard/cards/RelayMiddleman.py
@@ -1,0 +1,22 @@
+class RelayMiddleman(object):
+    """
+    The RelayMiddleman class serves as a base from which a user might derive
+    their own relay middle man class.  This base class implements the simplest
+    Man-in-the-Middle:  the NoOp.
+    """
+
+    def handleInPDU(self, inPDU: bytes):
+        """
+        This method is called on each PDU that is fed into the realy (vdpu -> vicc).
+        It may be overwritten to modify the packages send from the terminal to the 
+        real smart card.
+        """
+        return inPDU
+
+    def handleOutPDU(self, outPDU: bytes):
+        """
+        This method is called on each PDU that is produced by the relay (vicc -> vdpu).
+        It may be overwritten to modify the packages send from the real smart card to the
+        terminal.
+        """
+        return outPDU


### PR DESCRIPTION
This PR extends the Relay class in such a way that it can be flexibly used as a Man-in-the-Middle.
It adds a new Command-Line Flag (--mitm) which takes a path to a Python File that contains a function `get_MitM()`, which, when called, produces an object with a `handleInPDU` and a `handleOutPDU` method. This object is then used by the Relay-VICC as a Man-in-the-Middel, meaning it passes any packets to these `handle`-Methods and relays the result of them (instead of the original packets).
For the MitM flag to work properly, the path which is given to it needs to be in Python's load path (eg PYTHONPATH).
The --mitm flag only applies when the Relay type is used. If the Relay is used without specifying a MitM-Module, the default `RelayMiddleman` is used, which does nothing at all.  The `RelayMiddleman` class may be used by the user to create custom middlemans by inheriting from it.