### PR TITLE
docs: fix simple typo, offest -> offset

### DIFF
--- a/docs/_static/underscore.js
+++ b/docs/_static/underscore.js
@@ -1313,7 +1313,7 @@
         source += "';\n" + evaluate + "\n__p+='";
       }
 
-      // Adobe VMs need the match returned to produce the correct offest.
+      // Adobe VMs need the match returned to produce the correct offset.
       return match;
     });
     source += "';\n";


### PR DESCRIPTION
There is a small typo in docs/_static/underscore.js.

Should read `offset` rather than `offest`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md