### PR TITLE
vpcd: Initialize variable also on Windows

### DIFF
--- a/virtualsmartcard/src/vpcd/vpcd.c
+++ b/virtualsmartcard/src/vpcd/vpcd.c
@@ -179,6 +179,7 @@ SOCKET waitforclient(SOCKET server, long secs, long usecs)
     fd_set rfds;
     struct timeval tv;
 
+    FD_ZERO(&rfds);
 #pragma warning(disable:4127)
     FD_SET(server, &rfds);
 #pragma warning(default:4127)


### PR DESCRIPTION
This should fix the appveyor build failure:

C:\projects\vsmartcard\virtualsmartcard\src\vpcd\vpcd.c(183): error C4700: uninitialized local variable 'rfds' used [C:\projects\vsmartcard\virtualsmartcard\win32\BixVReader\BixVReader.vcxproj]