### PR TITLE
Fallback to hashlib instead of deprecated libs

### DIFF
--- a/virtualsmartcard/src/vpicc/virtualsmartcard/CryptoUtils.py
+++ b/virtualsmartcard/src/vpicc/virtualsmartcard/CryptoUtils.py
@@ -31,8 +31,8 @@ try:
 
 except ImportError:
     # PyCrypto not available.  Use the Python standard library.
-    import hmac as HMAC
-    import sha as SHA1
+    from hashlib import hmac as HMAC
+    from hashlib import sha as SHA1
 
 CYBERFLEX_IV = b'\x00' * 8
 


### PR DESCRIPTION
hashlib is present in python since 2.5, however the previous versions only worked with PyCrypto installed.