### PR TITLE
Drop unused SHA1 import

### DIFF
--- a/virtualsmartcard/src/vpicc/virtualsmartcard/CryptoUtils.py
+++ b/virtualsmartcard/src/vpicc/virtualsmartcard/CryptoUtils.py
@@ -27,12 +27,11 @@ from virtualsmartcard.utils import inttostring
 try:
     # Use PyCrypto (if available)
     from Crypto.Cipher import DES3, DES, AES, ARC4  # @UnusedImport
-    from Crypto.Hash import HMAC, SHA as SHA1
+    from Crypto.Hash import HMAC
 
 except ImportError:
     # PyCrypto not available.  Use the Python standard library.
     from hashlib import hmac as HMAC
-    from hashlib import sha as SHA1
 
 CYBERFLEX_IV = b'\x00' * 8
 


### PR DESCRIPTION
It is unused since commit 36970a26d72b4e2a63170b80c6af2b733ea14876
("Replace PBKDF2 class by python stdlib implementation").

Fixes #218