### PR TITLE
Correct hmac import from Python stdlib

### DIFF
--- a/virtualsmartcard/src/vpicc/virtualsmartcard/CryptoUtils.py
+++ b/virtualsmartcard/src/vpicc/virtualsmartcard/CryptoUtils.py
@@ -31,7 +31,7 @@ try:
 
 except ImportError:
     # PyCrypto not available.  Use the Python standard library.
-    from hashlib import hmac as HMAC
+    import hmac as HMAC
 
 CYBERFLEX_IV = b'\x00' * 8
 


### PR DESCRIPTION
As described in #223 and in the commit message of the commit in this PR in more detail, the changed `hmac` import from commit 82c0c4fdd2d99150ed11c188fbc0586512b13edb (PR #215) does not appear to work and also does not match with what the example in the [official Python 3.10 documentation](https://docs.python.org/3/library/hashlib.html) uses, so this reverts the import to the working version again.

@Gu1nness: Anything I might possibly be missing here?