### PR TITLE
Port from PyCrypto to PyCryptodome

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -37,7 +37,7 @@ install:
  - python -m pip install --upgrade pip
  - pip install virtualenv
  - pip install -U setuptools
- - pip install pycryptodome
+ - pip install pycryptodomex
  - pip install pbkdf2
  - pip install Pillow
  - pip install pyreadline

--- a/docs/_sources/virtualsmartcard/README.txt
+++ b/docs/_sources/virtualsmartcard/README.txt
@@ -103,7 +103,7 @@ Depending on your usage of the |vpicc| you may need to install the following:
 
 - Python_
 - pyscard_ (relaying a local smart card with `--type=relay`)
-- PyCrypto_, PBKDF2_, PIL_, readline_ or PyReadline_ (emulation of electronic
+- PyCryptodome_, PBKDF2_, PIL_, readline_ or PyReadline_ (emulation of electronic
   passport with `--type=ePass`)
 - OpenPACE_ (emulation of German identity card with `--type=nPA`)
 - libqrencode_ (to print a QR code on the command line for `vpcd-config`; an
@@ -314,7 +314,7 @@ Notes and References
 .. _PCSC-lite: https://pcsclite.apdu.fr/
 .. _Python: http://www.python.org/
 .. _pyscard: http://pyscard.sourceforge.net/
-.. _PyCrypto: http://pycrypto.org/
+.. _PyCryptodome: https://www.pycryptodome.org/
 .. _PBKDF2: https://www.dlitz.net/software/python-pbkdf2/
 .. _readline: https://docs.python.org/3.3/library/readline.html
 .. _PyReadline: https://pypi.python.org/pypi/pyreadline

--- a/docs/virtualsmartcard/README.html
+++ b/docs/virtualsmartcard/README.html
@@ -211,7 +211,7 @@ responses via NFC to a contact-less smart card that signs the mail.</p>
 <ul class="simple">
 <li><p><a class="reference external" href="http://www.python.org/">Python</a> <a class="footnote-reference brackets" href="#id7" id="id8">3</a></p></li>
 <li><p><a class="reference external" href="http://pyscard.sourceforge.net/">pyscard</a> <a class="footnote-reference brackets" href="#id9" id="id10">4</a> (relaying a local smart card with <cite>–type=relay</cite>)</p></li>
-<li><p><a class="reference external" href="http://pycrypto.org/">PyCrypto</a> <a class="footnote-reference brackets" href="#id11" id="id12">5</a>, <a class="reference external" href="https://www.dlitz.net/software/python-pbkdf2/">PBKDF2</a> <a class="footnote-reference brackets" href="#id13" id="id14">6</a>, <a class="reference external" href="http://www.pythonware.com/products/pil/">PIL</a> <a class="footnote-reference brackets" href="#id19" id="id20">9</a>, <a class="reference external" href="https://docs.python.org/3.3/library/readline.html">readline</a> <a class="footnote-reference brackets" href="#id15" id="id16">7</a> or <a class="reference external" href="https://pypi.python.org/pypi/pyreadline">PyReadline</a> <a class="footnote-reference brackets" href="#id17" id="id18">8</a> (emulation of electronic
+<li><p><a class="reference external" href="https://www.pycryptodome.org/">PyCryptodome</a> <a class="footnote-reference brackets" href="#id11" id="id12">5</a>, <a class="reference external" href="https://www.dlitz.net/software/python-pbkdf2/">PBKDF2</a> <a class="footnote-reference brackets" href="#id13" id="id14">6</a>, <a class="reference external" href="http://www.pythonware.com/products/pil/">PIL</a> <a class="footnote-reference brackets" href="#id19" id="id20">9</a>, <a class="reference external" href="https://docs.python.org/3.3/library/readline.html">readline</a> <a class="footnote-reference brackets" href="#id15" id="id16">7</a> or <a class="reference external" href="https://pypi.python.org/pypi/pyreadline">PyReadline</a> <a class="footnote-reference brackets" href="#id17" id="id18">8</a> (emulation of electronic
 passport with <cite>–type=ePass</cite>)</p></li>
 <li><p><a class="reference external" href="https://github.com/frankmorgner/openpace">OpenPACE</a> <a class="footnote-reference brackets" href="#id21" id="id22">10</a> (emulation of German identity card with <cite>–type=nPA</cite>)</p></li>
 <li><p><a class="reference external" href="https://fukuchi.org/works/qrencode/">libqrencode</a> <a class="footnote-reference brackets" href="#id23" id="id24">11</a> (to print a QR code on the command line for <cite>vpcd-config</cite>; an
@@ -563,7 +563,7 @@ more than welcome! Please use our <a class="reference external" href="https://gi
 <dd><p><a class="reference external" href="http://pyscard.sourceforge.net/">http://pyscard.sourceforge.net/</a></p>
 </dd>
 <dt class="label" id="id11"><span class="brackets"><a class="fn-backref" href="#id12">5</a></span></dt>
-<dd><p><a class="reference external" href="http://pycrypto.org/">http://pycrypto.org/</a></p>
+<dd><p><a class="reference external" href="https://www.pycryptodome.org/">https://www.pycryptodome.org/</a></p>
 </dd>
 <dt class="label" id="id13"><span class="brackets"><a class="fn-backref" href="#id14">6</a></span></dt>
 <dd><p><a class="reference external" href="https://www.dlitz.net/software/python-pbkdf2/">https://www.dlitz.net/software/python-pbkdf2/</a></p>

--- a/virtualsmartcard/doc/README.txt.in
+++ b/virtualsmartcard/doc/README.txt.in
@@ -103,7 +103,7 @@ Depending on your usage of the |vpicc| you may need to install the following:
 
 - Python_
 - pyscard_ (relaying a local smart card with `--type=relay`)
-- PyCrypto_, PBKDF2_, PIL_, readline_ or PyReadline_ (emulation of electronic
+- PyCryptodome, PBKDF2_, PIL_, readline_ or PyReadline_ (emulation of electronic
   passport with `--type=ePass`)
 - OpenPACE_ (emulation of German identity card with `--type=nPA`)
 - libqrencode_ (to print a QR code on the command line for `vpcd-config`; an
@@ -320,7 +320,7 @@ requiremets are installed as follows::
     sudo apt-get install python2.7-dev
     curl https://bootstrap.pypa.io/pip/2.7/get-pip.py -o get-pip.py
     python2.7 get-pip.py
-    python2.7 -m pip install pycrypto pyscard
+    python2.7 -m pip install pycryptodomex pyscard
     python2.7 readpass.py --no-gui
     git clone https://github.com/henryk/cyberflex-shell
     cd cyberflex-shell
@@ -354,7 +354,7 @@ Notes and References
 .. _PCSC-lite: https://pcsclite.apdu.fr/
 .. _Python: http://www.python.org/
 .. _pyscard: http://pyscard.sourceforge.net/
-.. _PyCrypto: http://pycrypto.org/
+.. _PyCryptodome: https://www.pycryptodome.org/
 .. _PBKDF2: https://www.dlitz.net/software/python-pbkdf2/
 .. _readline: https://docs.python.org/3.3/library/readline.html
 .. _PyReadline: https://pypi.python.org/pypi/pyreadline

--- a/virtualsmartcard/src/vpicc/virtualsmartcard/CryptoUtils.py
+++ b/virtualsmartcard/src/vpicc/virtualsmartcard/CryptoUtils.py
@@ -25,12 +25,12 @@ from random import randint
 from virtualsmartcard.utils import inttostring
 
 try:
-    # Use PyCrypto (if available)
-    from Crypto.Cipher import DES3, DES, AES, ARC4  # @UnusedImport
-    from Crypto.Hash import HMAC
+    # Use PyCryptodome (if available)
+    from Cryptodome.Cipher import DES3, DES, AES, ARC4  # @UnusedImport
+    from Cryptodome.Hash import HMAC
 
 except ImportError:
-    # PyCrypto not available.  Use the Python standard library.
+    # PyCryptodome not available.  Use the Python standard library.
     import hmac as HMAC
 
 CYBERFLEX_IV = b'\x00' * 8
@@ -83,7 +83,7 @@ def get_cipher_keylen(cipherspec):
     # cipher = globals().get(cipherparts[0].upper(), None)
     # Note: return cipher.key_size does not work on Ubuntu, because e.g.
     # AES.key_size == 0
-    if cipher == "AES":  # Pycrypto uses AES128
+    if cipher == "AES":  # PyCryptodome uses AES128
         return 16
     elif cipher == "DES":
         return 8

--- a/virtualsmartcard/src/vpicc/virtualsmartcard/CryptoUtils.py
+++ b/virtualsmartcard/src/vpicc/virtualsmartcard/CryptoUtils.py
@@ -201,7 +201,6 @@ def decrypt(cipherspec, key, data, iv=None):
 
 
 def hash(hashmethod, data):
-    from Crypto.Hash import SHA, MD5  # , RIPEMD
     hash_class = locals().get(hashmethod.upper(), None)
     if hash_class is None:
         logging.error("Unknown Hash method %s" % hashmethod)

--- a/virtualsmartcard/src/vpicc/virtualsmartcard/SEutils.py
+++ b/virtualsmartcard/src/vpicc/virtualsmartcard/SEutils.py
@@ -683,8 +683,6 @@ class Security_Environment(object):
                      P1-P2 different from '0000'
         """
 
-        from Crypto.PublicKey import RSA, DSA
-
         cipher = self.ct.algorithm
 
         c_class = locals().get(cipher, None)

--- a/virtualsmartcard/src/vpicc/virtualsmartcard/cards/cryptoflex.py
+++ b/virtualsmartcard/src/vpicc/virtualsmartcard/cards/cryptoflex.py
@@ -98,8 +98,7 @@ class CryptoflexSE(Security_Environment):
             Used to specify the key length. The mapping is: 0x40 => 256 Bit,
             0x60 => 512 Bit, 0x80 => 1024
         """
-        from Crypto.PublicKey import RSA
-        from Crypto.Util.randpool import RandomPool
+        from Cryptodome.PublicKey import RSA
 
         keynumber = p1  # TODO: Check if key exists
 
@@ -110,8 +109,7 @@ class CryptoflexSE(Security_Environment):
         else:
             keylength = keylength_dict[p2]
 
-        rnd = RandomPool()
-        PublicKey = RSA.generate(keylength, rnd.get_bytes)
+        PublicKey = RSA.generate(keylength)
         self.dst.key = PublicKey
 
         e_in = struct.unpack("<i", data)


### PR DESCRIPTION
As suggested in https://github.com/frankmorgner/vsmartcard/issues/223#issuecomment-1234280271, this ports from the deprecated and unmaintained PyCrypto to the recommended and maintained PyCryptodome fork, s. discussion there and commit messages for more details.

Further comments:

1) The (only) use case I explicitly tested was retrieving my personal data using the German passport (nPA) with a virtual smartcard reader (Smart Card Reader Android app running under LineageOS, AusweisApp2 and vicc from this repo running under Debian testing, using Python 3.10.7). The [PyCryptodome doc](https://www.pycryptodome.org/src/introduction) says that Python 2.7 is also supported, but I didn't explicitly test that.

2) From how I understand it, generating/updating the docs should be possible by running the corresponding make commands from within the `doc` subdirectory. However, I got various warnings/errors and a huge diff from what is currently in this repo that looks mostly unrelated to this change when e.g. running `make html`, so decided to rather manually adapt the places mentioning PyCrypto there as well (and leave automated update to a run done on some "reference machine" or somesuch?).