### PR TITLE
avoid unnecessary RTTs for communication

### DIFF
--- a/remote-reader/app/src/main/java/com/vsmartcard/remotesmartcardreader/app/VPCDWorker.java
+++ b/remote-reader/app/src/main/java/com/vsmartcard/remotesmartcardreader/app/VPCDWorker.java
@@ -179,13 +179,12 @@ class VPCDWorker extends AsyncTask<VPCDWorker.VPCDWorkerParams, Void, Void> {
     private void sendToVPCD(byte[] data) throws IOException {
         /* convert length to network byte order.
         Note that Java always uses network byte order internally. */
-        byte[] length = new byte[2];
-        length[0] = (byte) (data.length >> 8);
-        length[1] = (byte) (data.length & 0xff);
-        outputStream.write(length);
+        byte[] packet = new byte[2 + data.length];
+        packet[0] = (byte) (data.length >> 8);
+        packet[1] = (byte) (data.length & 0xff);
+        System.arraycopy(data, 0, packet, 2, data.length);
 
-        outputStream.write(data, 0, data.length);
-
+        outputStream.write(packet);
         outputStream.flush();
     }
 

--- a/virtualsmartcard/src/vpcd/vpcd.c
+++ b/virtualsmartcard/src/vpcd/vpcd.c
@@ -219,6 +219,7 @@ static ssize_t sendToVICC(struct vicc_ctx *ctx, size_t length, const unsigned ch
 {
     ssize_t r;
     uint16_t size;
+    char *sendBuffer;
 
     if (!ctx || length > 0xFFFF) {
         errno = EINVAL;
@@ -226,11 +227,11 @@ static ssize_t sendToVICC(struct vicc_ctx *ctx, size_t length, const unsigned ch
     }
 
     /* send size of message on 2 bytes */
+    sendBuffer = (char *) alloca(length + 2);
     size = htons((uint16_t) length);
-    r = sendall(ctx->client_sock, (void *) &size, sizeof size);
-    if (r == sizeof size)
-        /* send message */
-        r = sendall(ctx->client_sock, buffer, length);
+    memcpy(sendBuffer, &size, 2);
+    memcpy(sendBuffer + 2, buffer, length);
+    r = sendall(ctx->client_sock, sendBuffer, length + 2);
 
     if (r < 0)
         vicc_eject(ctx);

--- a/virtualsmartcard/src/vpcd/vpcd.c
+++ b/virtualsmartcard/src/vpcd/vpcd.c
@@ -226,8 +226,14 @@ static ssize_t sendToVICC(struct vicc_ctx *ctx, size_t length, const unsigned ch
         return -1;
     }
 
+    /* allocate buffer for outgoing message */
+    sendBuffer = (char *) malloc(length + 2);
+    if (sendBuffer == NULL) {
+        errno = ENOMEM;
+	return -1;
+    }
+
     /* send size of message on 2 bytes */
-    sendBuffer = (char *) alloca(length + 2);
     size = htons((uint16_t) length);
     memcpy(sendBuffer, &size, 2);
     memcpy(sendBuffer + 2, buffer, length);
@@ -236,6 +242,7 @@ static ssize_t sendToVICC(struct vicc_ctx *ctx, size_t length, const unsigned ch
     if (r < 0)
         vicc_eject(ctx);
 
+    free(sendBuffer);
     return r;
 }
 


### PR DESCRIPTION
when using remote-reader + vpcd, the request is sent by doing 2 `sendall` operations on the socket (one for the length, another for the data). this splits the request into 2 TCP segments, meaning Nagle's algorithm kicks in and holds the second segment until an ACK for the first is received. this introduces an unnecessary RTT.

remote-reader also does this on their end, which introduces another RTT. these RTTs can end up representing most of the time the user spends waiting (with Android they're usually on the order of hundreds of milliseconds).

in conclusion, this makes overall operation ~3x faster. for example, in my case `pkcs15-tool -c` drops from 6.3 seconds to about 2 seconds.