### PR TITLE
virtualsmartcard: disable build of openpace

### DIFF
--- a/virtualsmartcard/MacOSX/Makefile.am
+++ b/virtualsmartcard/MacOSX/Makefile.am
@@ -8,20 +8,18 @@ all-local:
 OSX_TOOLS_DIR = "$(shell xcode-select -p)/Platforms/MacOSX.platform/Developer/SDKs"
 OSX_TOOL_DIR ?= "$(OSX_TOOLS_DIR)/$(shell ls -1 $(OSX_TOOLS_DIR) | sort -n -k2 -t. -r | head -1)/usr"
 OSX_TARGETDIR = $(abs_top_builddir)/$(PACKAGE_TARNAME)-$(PACKAGE_VERSION)_osx
-osx: $(OPENPACE_MAKEFILE)
-	@echo Compiling OpenPACE
-	$(MAKE) -C $(OPENPACE) osx
+osx:
 	rm -rf $(OSX_TARGETDIR) dmg $(top_builddir)/$(PACKAGE_TARNAME)-$(PACKAGE_VERSION)_osx.dmg
 	@echo Configuring virtualsmartcard for IFD bundle
 	cd $(top_builddir) && ./configure --enable-infoplist --prefix=/Library/VirtualSmartCard \
-		CFLAGS="-arch x86_64" \
+		CFLAGS="-arch x86_64 -arch arm64" \
 		--enable-serialdropdir=/usr$(OSX_SERIAL_LOCAL_PREFIX)/libexec/SmartCardServices/drivers/ifd-vpcd.bundle/Contents/MacOS \
 		--enable-serialconfdir=/usr$(OSX_SERIAL_LOCAL_PREFIX)/libexec/SmartCardServices/drivers/ifd-vpcd.bundle/Contents
 	@echo Compiling virtualsmartcard
 	make -C $(top_builddir) clean install DESTDIR=$(OSX_TARGETDIR)
 	@echo Configuring virtualsmartcard for builtin libpcsclite
 	cd $(top_builddir) && ./configure --enable-infoplist --prefix=/Library/VirtualSmartCard \
-		CFLAGS="-arch x86_64" \
+		CFLAGS="-arch x86_64 -arch arm64" \
 		--enable-serialdropdir=/usr$(OSX_SERIAL_LOCAL_PREFIX)/libexec/SmartCardServices/drivers/ifd-vpcd.bundle/Contents/MacOS \
 		--enable-serialconfdir=/usr$(OSX_SERIAL_LOCAL_PREFIX)/libexec/SmartCardServices/drivers/ifd-vpcd.bundle/Contents \
 		--enable-libpcsclite
@@ -32,21 +30,4 @@ osx: $(OPENPACE_MAKEFILE)
 	pkgbuild --nopayload --identifier com.vsmartcard.virtualsmartcard.mac.uninstall --scripts MacOSX_uninstall Uninstall_VirtualSmartCard.pkg
 	mkdir -p dmg
 	cp *.pkg dmg
-	cp $(OPENPACE)/cross/*.pkg dmg
 	hdiutil create -srcfolder dmg -volname "$(PACKAGE_STRING) for Mac OS X" $(top_builddir)/$(PACKAGE_TARNAME)-$(PACKAGE_VERSION)_osx.dmg
-
-
-
-OPENPACE=$(abs_builddir)/openpace
-OPENPACE_CONFIGURE_AC=$(OPENPACE)/configure.ac
-OPENPACE_CONFIGURE=$(OPENPACE)/configure
-OPENPACE_MAKEFILE=$(OPENPACE)/Makefile
-
-$(OPENPACE_CONFIGURE_AC):
-	git clone https://github.com/frankmorgner/openpace.git $(OPENPACE)
-
-$(OPENPACE_CONFIGURE): $(OPENPACE_CONFIGURE_AC)
-	cd $(OPENPACE) && autoreconf --verbose --install --symlink
-
-$(OPENPACE_MAKEFILE): $(OPENPACE_CONFIGURE)
-	cd $(OPENPACE) && ./configure --enable-openssl-install


### PR DESCRIPTION
for now, don't hassle with creating fat ssl binaries by using lipo. just remove openpace from the binaries for now.

fixes https://github.com/frankmorgner/vsmartcard/issues/242