### PR TITLE
Remote Smart Card Reader: Bump outdated

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,9 +84,9 @@ jobs:
   remote-reader-ubuntu:
     runs-on: ubuntu-20.04
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - run: .github/build-remote-reader.sh
-    - uses: actions/upload-artifact@v2
+    - uses: actions/upload-artifact@v4
       with:
         name: remote-reader
         path:

--- a/remote-reader/app/build.gradle
+++ b/remote-reader/app/build.gradle
@@ -48,11 +48,10 @@ repositories {
 
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
-    testImplementation 'junit:junit:4.12'
-    implementation 'androidx.appcompat:appcompat:1.2.0'
-    implementation 'com.google.android.material:material:1.3.0'
+    testImplementation 'junit:junit:4.13.2'
+    implementation 'androidx.appcompat:appcompat:1.6.1'
+    implementation 'com.google.android.material:material:1.9.0'
     implementation 'androidx.legacy:legacy-support-v4:1.0.0'
 
-    implementation 'com.journeyapps:zxing-android-embedded:3.2.0@aar'
-    implementation 'com.google.zxing:core:3.2.1'
+    implementation 'com.journeyapps:zxing-android-embedded:4.3.0'
 }

--- a/remote-reader/app/build.gradle
+++ b/remote-reader/app/build.gradle
@@ -1,13 +1,14 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 29
+    compileSdkVersion 33
 
     defaultConfig {
         applicationId "com.vsmartcard.remotesmartcardreader.app"
         // NFC reader mode was added in KitKat
         minSdkVersion 19
-        targetSdkVersion 29
+        //noinspection ExpiredTargetSdkVersion
+        targetSdkVersion 30
         versionCode 7
         versionName "2.3"
     }

--- a/remote-reader/build.gradle
+++ b/remote-reader/build.gradle
@@ -3,7 +3,7 @@
 buildscript {
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:4.1.2'
@@ -15,8 +15,8 @@ buildscript {
 
 allprojects {
     repositories {
-        jcenter()
         google()
+        mavenCentral()
     }
 }
 

--- a/remote-reader/build.gradle
+++ b/remote-reader/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.1.2'
+        classpath 'com.android.tools.build:gradle:7.4.2'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/remote-reader/gradle/wrapper/gradle-wrapper.properties
+++ b/remote-reader/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.6-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.10-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
I updated some stuff to correctly compile Android application. I tested Gradle compilation process on Manjaro and Ubuntu 20.04 (GitHub runner, click [here](https://github.com/user-attachments/files/16790662/job-logs.txt) to download the `job-log` or [here](https://github.com/miticollo/vsmartcard/actions/runs/10607011107/job/29398735847) to see the job). I installed and tested the (debuggable) app on Samsung Galaxy S10+ with Android 12.

Some update details are added into commit body.