### PR TITLE
Remote Smart Card Reader: Upgrading the Gradle Wrapper

### DIFF
--- a/remote-reader/gradle/wrapper/gradle-wrapper.properties
+++ b/remote-reader/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.10-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.12.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
A little upgrade. I tested Gradle compilation process on Ubuntu 20.04 (Github Actions). I installed and tested the (debuggable) app on Samsung Galaxy S10+ with Android 12.