### PR TITLE
macos: fix the "(null):(null)" in system_profiler SPSmartCardsDataType output

### DIFF
--- a/virtualsmartcard/src/ifd-vpcd/Info.plist.in
+++ b/virtualsmartcard/src/ifd-vpcd/Info.plist.in
@@ -16,6 +16,10 @@
 	<string>????</string>
 	<key>CFBundleVersion</key>
 	<string>@VERSION@</string>
+	<key>CFBundleShortVersionString</key>
+        <string>@VERSION@</string>
+        <key>CFBundleIdentifier</key>
+        <string>io.github.frankmorgner</string>
 
 	<key>ifdManufacturerString</key>
 	<string>Virtual Smart Card Architecture</string>
@@ -41,7 +45,7 @@
 
 	<key>ifdFriendlyName</key>
 	<array>
-		<string>@VPCDHOST@:0x8C7B</string>
+		<string>Virtual PCD</string>
 	</array>
 
 	<key>Copyright</key>


### PR DESCRIPTION
Also change the name of the reader from "/dev/null:0x8C7B" to "Virtual PCD"